### PR TITLE
lock node engine to specific binary

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "express": "~4.9.x"
   },
   "engines": {
-    "node": "0.12.x"
+    "node": "0.12.2"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
We should use this as an example of dev:prod parity (https://devcenter.heroku.com/articles/troubleshooting-node-deploys#compare-node-and-npm-versions). 

/cc @markpundsack @friism @jonmountjoy 

There are several places in the DevCenter docs where I should probably also replace the `.x` syntax with something specific to lead by example. It's cool that the buildpack can resolve node and npm versions with semver, but it's a bad practice in production & leads to lots of customer frustration.

