### PR TITLE
remove localhost from startup message

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,5 +9,5 @@ app.get('/', function(request, response) {
 });
 
 app.listen(app.get('port'), function() {
-  console.log("Node app is running at localhost:" + app.get('port'));
+  console.log('Node app is running on port', app.get('port'));
 });


### PR DESCRIPTION
@friism @jonmountjoy Goal of this is to improve the first-run experience inside of Docker. It's confusing to see "running on localhost:5000" when in fact it's not because it's in a Docker container. Is this a satisfactory startup message instead?