### PR TITLE
Update Procfile to use --inspect

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: node --debug=5858 index.js
+web: node --inspect=5858 index.js


### PR DESCRIPTION
When running "heroku local web", I was presented with this error: "(node:15784) [DEP0062] DeprecationWarning: node --debug and node --debug-brk are invalid. Please use node --inspect or node --inspect-brk instead."

Changing the Procfile to use "node --inspect" fixed this issue.