### PR TITLE
fix `Deploy to Heroku`

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ $ heroku open
 ```
 or
 
-[![Deploy to Heroku](https://www.herokucdn.com/deploy/button.png)](https://heroku.com/deploy)
+[![Deploy to Heroku](https://www.herokucdn.com/deploy/button.png)](https://dashboard.heroku.com/new?template=https%3A%2F%2Fgithub.com%2Fheroku%2Fnode-js-getting-started)
 
 ## Documentation
 


### PR DESCRIPTION
`https://heroku.com/deploy` didn't work on [Brave](https://github.com/brave)