### PR TITLE
Upgrade ejs modules

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: node index.js
+web: npm start

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test": "node test.js"
   },
   "dependencies": {
-    "ejs": "^2.5.6",
+    "ejs": "^3.1.5",
     "express": "^4.15.2"
   },
   "devDependencies": {

--- a/views/pages/db.ejs
+++ b/views/pages/db.ejs
@@ -1,12 +1,12 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <% include ../partials/header.ejs %>
+  <%- include ("../partials/header.ejs") %>
 </head>
 
 <body>
 
-<% include ../partials/nav.ejs %>
+<%- include ("../partials/nav.ejs") %>
 
 <div class="container">
 <h2>Database Results</h2>

--- a/views/pages/index.ejs
+++ b/views/pages/index.ejs
@@ -1,12 +1,12 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <% include ../partials/header.ejs %>
+  <%- include ("../partials/header.ejs") %>
 </head>
 
 <body>
 
-  <% include ../partials/nav.ejs %>
+  <%- include ("../partials/nav.ejs") %>
 
 <div class="jumbotron text-center">
   <div class="container">


### PR DESCRIPTION
Updates ejs module to the next major version, and makes a few fixes to support the next version. This also makes `npm start` the web command in the Procfile.

Fixes: https://github.com/heroku/node-js-getting-started/issues/218