### PR TITLE
Update to node 16

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.3.0",
   "description": "A sample Node.js app using Express 4",
   "engines": {
-    "node": "14.x"
+    "node": "16.x"
   },
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Node 16 is the default as of 1/28: https://devcenter.heroku.com/changelog-items/2349. 