### PR TITLE
Update default port

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ $ npm install
 $ npm start
 ```
 
-Your app should now be running on [localhost:5000](http://localhost:5000/).
+Your app should now be running on [localhost:5001](http://localhost:5001/).
 
 ## Deploying to Heroku
 


### PR DESCRIPTION
    Background:
    The README specifies that the server runs on port 5000, but it runs on 5001.

    Modifications:
    Update README to specify port 5001.

    Result:
    The port specified by the README is correct when booting the default getting-started server.