### PR TITLE
Add comment to .env

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,5 @@
+# NOTE: 
+# This .env file is checked into git for demonstration purposes only. 
+# We recommend adding the `.env` file to your `.gitignore` file and 
+# removing it from git cache with the command `git rm --cached .env`
 TIMES=2


### PR DESCRIPTION
Checking in a `.env` file into git is not best practice. We have historically included this file in this template project to make our getting started guide easier for beginners to consume and currently we'd like to continue that ease of use. From discussions in #296 a reasonable alternative to removing the file would be to add a comment in the `.env` file (as this PR does) which explains why the file is in git and how to remove it.

Fixes #47