### PR TITLE
Update to Node.js 22.x

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "tape": "^5.7.4"
       },
       "engines": {
-        "node": "20.x"
+        "node": "22.x"
       }
     },
     "node_modules/@ljharb/resumer": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.3.0",
   "description": "A sample Node.js app using Express 4",
   "engines": {
-    "node": "20.x"
+    "node": "22.x"
   },
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Node.js 22.x is now the Active LTS release line as of 10-29-2024 ([source](https://github.com/nodejs/Release)). In accordance with our support policy, it should be the default version.