### PR TITLE
Updated with fir-related content and links

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,10 +37,6 @@ $ git push heroku main
 $ heroku open
 ```
 
-or
-
-[![Deploy to Heroku](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy)
-
 ### Deploy on [Fir](https://devcenter.heroku.com/articles/generations#fir)
 
 By default, apps on [Fir][fir] use 1X-Classic dynos. To create an app on [Fir][fir] you'll need to 

--- a/README.md
+++ b/README.md
@@ -2,9 +2,10 @@
 
 A barebones Node.js app using [Express](https://expressjs.com/).
 
-This application supports the [Getting Started on Heroku with Node.js](https://devcenter.heroku.com/articles/getting-started-with-nodejs) 
-and [Getting Started on Heroku Fir with Node.js](https://devcenter.heroku.com/articles/getting-started-with-nodejs-fir) 
-articles - check it out.
+This application supports the tutorials for both the [Cedar and Fir generations](https://devcenter.heroku.com/articles/generations) of the Heroku platform. You can check them out here:
+
+* [Getting Started on Heroku with Node.js](https://devcenter.heroku.com/articles/getting-started-with-nodejs)
+* [Getting Started on Heroku Fir with Node.js](https://devcenter.heroku.com/articles/getting-started-with-nodejs-fir)
 
 ## Running Locally
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 A barebones Node.js app using [Express](https://expressjs.com/).
 
-This application supports the [Getting Started on Heroku with Node.js](https://devcenter.heroku.com/articles/getting-started-with-nodejs) article - check it out.
+This application supports the [Getting Started on Heroku with Node.js](https://devcenter.heroku.com/articles/getting-started-with-nodejs) 
+and [Getting Started on Heroku Fir with Node.js](https://devcenter.heroku.com/articles/getting-started-with-nodejs-fir) 
+articles - check it out.
 
 ## Running Locally
 
@@ -21,7 +23,11 @@ Your app should now be running on [localhost:5006](http://localhost:5006/).
 
 Using resources for this example app counts towards your usage. [Delete your app](https://devcenter.heroku.com/articles/heroku-cli-commands#heroku-apps-destroy) and [database](https://devcenter.heroku.com/articles/heroku-postgresql#removing-the-add-on) as soon as you are done experimenting to control costs.
 
-By default, apps use Eco dynos if you are subscribed to Eco. Otherwise, it defaults to Basic dynos. The Eco dynos plan is shared across all Eco dynos in your account and is recommended if you plan on deploying many small apps to Heroku. Learn more about our low-cost plans [here](https://blog.heroku.com/new-low-cost-plans).
+### Deploy on [Cedar][cedar]
+
+By default, apps use Eco dynos on [Cedar][cedar] if you are subscribed to Eco. Otherwise, it defaults to Basic dynos. The 
+Eco dynos plan is shared across all Eco dynos in your account and is recommended if you plan on deploying many small apps 
+to Heroku. Learn more about our low-cost plans [here](https://blog.heroku.com/new-low-cost-plans).
 
 Eligible students can apply for platform credits through our new [Heroku for GitHub Students program](https://blog.heroku.com/github-student-developer-program).
 
@@ -30,16 +36,34 @@ $ heroku create
 $ git push heroku main
 $ heroku open
 ```
+
 or
 
 [![Deploy to Heroku](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy)
+
+### Deploy on [Fir](https://devcenter.heroku.com/articles/generations#fir)
+
+By default, apps on [Fir][fir] use 1X-Classic dynos. To create an app on [Fir][fir] you'll need to 
+[create a private space](https://devcenter.heroku.com/articles/working-with-private-spaces#create-a-private-space)
+first.
+
+```
+$ heroku spaces:create <space-name> --team <team-name> --generation fir
+$ heroku create --space <space-name>
+$ git push heroku main
+$ heroku open
+```
 
 ## Documentation
 
 For more information about using Node.js on Heroku, see these Dev Center articles:
 
 - [Getting Started on Heroku with Node.js](https://devcenter.heroku.com/articles/getting-started-with-nodejs)
+- [Getting Started on Heroku Fir with Node.js](https://devcenter.heroku.com/articles/getting-started-with-nodejs-fir)
 - [Heroku Node.js Support](https://devcenter.heroku.com/articles/nodejs-support)
 - [Node.js on Heroku](https://devcenter.heroku.com/categories/nodejs)
 - [Best Practices for Node.js Development](https://devcenter.heroku.com/articles/node-best-practices)
 - [Using WebSockets on Heroku with Node.js](https://devcenter.heroku.com/articles/node-websockets)
+
+[cedar]: https://devcenter.heroku.com/articles/generations#cedar
+[fir]: https://devcenter.heroku.com/articles/generations#fir

--- a/views/pages/index.ejs
+++ b/views/pages/index.ejs
@@ -16,12 +16,17 @@
     <h1>Getting Started on Heroku with Node.js</h1>
     <p>This is a sample Node application deployed to Heroku. It's a reasonably simple app - but a good foundation for understanding how to get the most out of the Heroku platform.</p>
     <a type="button" class="btn btn-lg btn-default" href="https://devcenter.heroku.com/articles/getting-started-with-nodejs"><span class="glyphicon glyphicon-flash"></span> Getting Started on Heroku with Node.js</a>
+    <a type="button" class="btn btn-lg btn-default" href="https://devcenter.heroku.com/articles/getting-started-with-nodejs-fir"><span class="glyphicon glyphicon-flash"></span> Getting Started on Heroku Fir with Node.js</a>
     <a type="button" class="btn btn-lg btn-primary" href="https://github.com/heroku/node-js-getting-started"><span class="glyphicon glyphicon-download"></span> Source on GitHub</a>
   </div>
 </div>
 <div class="container">
-  <div class="alert alert-info text-center" role="alert">
-    To deploy your own copy, and learn the fundamentals of the Heroku platform, head over to the <a href="https://devcenter.heroku.com/articles/getting-started-with-nodejs" class="alert-link">Getting Started on Heroku with Node.js</a> tutorial.
+  <div class="lead">
+    To deploy your own copy, and learn the fundamentals of the Heroku platform, head over to either of the following tutorials:
+    <ul>
+      <li><a href="https://devcenter.heroku.com/articles/getting-started-with-nodejs" class="alert-link">Getting Started on Heroku with Node.js</a></li>
+      <li><a href="https://devcenter.heroku.com/articles/getting-started-with-nodejs" class="alert-link">Getting Started on Heroku Fir with Node.js</a></li>
+    </ul>
   </div>
   <hr>
   <div class="row">
@@ -29,35 +34,47 @@
       <h3><span class="glyphicon glyphicon-info-sign"></span> How this sample app works</h3>
       <ul>
         <li>This app was deployed to Heroku, either using Git or by using <a href="https://github.com/heroku/node-js-getting-started">Heroku Button</a> on the repository.</li>
-
-        <li>When Heroku received the source code, it fetched all the dependencies in the <a href="https://github.com/heroku/node-js-getting-started/blob/main/package.json">package.json</a>, creating a deployable slug.</li>
-        <li>The platform then spins up a dyno, a lightweight container that provides an isolated environment in which the slug can be mounted and executed.</li>
+        <li>When Heroku received the source code, it fetched all the dependencies in the <a href="https://github.com/heroku/node-js-getting-started/blob/main/package.json">package.json</a>, creating a deployable build artifact.</li>
+        <li>The platform then spins up a dyno, a lightweight container that provides an isolated environment in which the build artifact can be mounted and executed.</li>
         <li>You can scale your app, manage it, and deploy over <a href="https://addons.heroku.com/">150 add-on services</a>, from the Dashboard or CLI.</li>
       </ul>
     </div>
     <div class="col-md-6">
       <h3><span class="glyphicon glyphicon-link"></span> Next Steps</h3>
       <ul>
-        <li>If you are following the <a href="https://devcenter.heroku.com/articles/getting-started-with-nodejs">Getting Started</a> guide, then please head back to the tutorial and follow the next steps!</li>
-        <li>If you deployed this app by deploying the Heroku Button, then in a command line shell, run:</li>
-        <ul>
-          <li><code>git clone https://github.com/heroku/node-js-getting-started.git</code> - this will create a local copy of the source code for the app</li>
-          <li><code>cd node-js-getting-started</code> - change directory into the local source code repository</li>
-          <li><code>heroku git:remote -a &lt;your-app-name></code> - associate the Heroku app with the repository</li>
-          <li>You'll now be set up to run the app locally, or <a href="https://devcenter.heroku.com/articles/getting-started-with-nodejs#push-local-changes">deploy changes</a> to Heroku</li>
-        </ul>
+        <li>If you are following the <a href="https://devcenter.heroku.com/articles/getting-started-with-nodejs" class="alert-link">Getting Started on Heroku with Node.js</a> or
+          <a href="https://devcenter.heroku.com/articles/getting-started-with-nodejs" class="alert-link">Getting Started on Heroku Fir with Node.js</a> guide,
+          then please head back to the tutorial and follow the next steps!</li>
       </ul>
       <h3><span class="glyphicon glyphicon-link"></span> Helpful Links</h3>
       <ul>
         <li><a href="https://www.heroku.com/home">Heroku</a></li>
         <li><a href="https://devcenter.heroku.com/">Heroku Dev Center</a></li>
         <li><a href="https://devcenter.heroku.com/articles/getting-started-with-nodejs">Getting Started on Heroku with Node.js</a></li>
+        <li><a href="https://devcenter.heroku.com/articles/getting-started-with-nodejs-fir">Getting Started on Heroku Fir with Node.js</a></li>
         <li><a href="https://devcenter.heroku.com/articles/deploying-nodejs">Deploying Node Apps on Heroku</a></li>
       </ul>
     </div>
   </div> <!-- row -->
-   <div class="alert alert-info text-center" role="alert">
-    Please do work through the Getting Started guide, even if you do know how to build such an application.  The guide covers the basics of working with Heroku, and will familiarize you with all the concepts you need in order to build and deploy your own apps.
+  <div>
+
+  </div>
+  <div class="row" style="margin-top:1em">
+    <div class="col-md-12">
+      <div class="alert alert-warning" role="alert">
+        <p><strong>For Cedar-generation Apps</strong></p>
+        <p>If you deployed this app by deploying the Heroku Button, then in a command line shell, run:</p>
+        <ul>
+          <li><code>git clone https://github.com/heroku/node-js-getting-started.git</code> - this will create a local copy of the source code for the app</li>
+          <li><code>cd node-js-getting-started</code> - change directory into the local source code repository</li>
+          <li><code>heroku git:remote -a &lt;your-app-name></code> - associate the Heroku app with the repository</li>
+          <li>You'll now be set up to run the app locally, or <a href="https://devcenter.heroku.com/articles/getting-started-with-nodejs#push-local-changes">deploy changes</a> to Heroku</li>
+        </ul>
+      </div>
+      <p class="alert alert-info" role="alert">
+        Please do work through the Getting Started guide, even if you do know how to build such an application.  The guide covers the basics of working with Heroku, and will familiarize you with all the concepts you need in order to build and deploy your own apps.
+      </p>
+    </div>
   </div>
 </div>
 

--- a/views/pages/index.ejs
+++ b/views/pages/index.ejs
@@ -33,7 +33,7 @@
     <div class="col-md-6">
       <h3><span class="glyphicon glyphicon-info-sign"></span> How this sample app works</h3>
       <ul>
-        <li>This app was deployed to Heroku, either using Git or by using <a href="https://github.com/heroku/node-js-getting-started">Heroku Button</a> on the repository.</li>
+        <li>This app was deployed to Heroku using Git.</li>
         <li>When Heroku received the source code, it fetched all the dependencies in the <a href="https://github.com/heroku/node-js-getting-started/blob/main/package.json">package.json</a>, creating a deployable build artifact.</li>
         <li>The platform then spins up a dyno, a lightweight container that provides an isolated environment in which the build artifact can be mounted and executed.</li>
         <li>You can scale your app, manage it, and deploy over <a href="https://addons.heroku.com/">150 add-on services</a>, from the Dashboard or CLI.</li>
@@ -61,16 +61,6 @@
   </div>
   <div class="row" style="margin-top:1em">
     <div class="col-md-12">
-      <div class="alert alert-warning" role="alert">
-        <p><strong>For Cedar-generation Apps</strong></p>
-        <p>If you deployed this app by deploying the Heroku Button, then in a command line shell, run:</p>
-        <ul>
-          <li><code>git clone https://github.com/heroku/node-js-getting-started.git</code> - this will create a local copy of the source code for the app</li>
-          <li><code>cd node-js-getting-started</code> - change directory into the local source code repository</li>
-          <li><code>heroku git:remote -a &lt;your-app-name></code> - associate the Heroku app with the repository</li>
-          <li>You'll now be set up to run the app locally, or <a href="https://devcenter.heroku.com/articles/getting-started-with-nodejs#push-local-changes">deploy changes</a> to Heroku</li>
-        </ul>
-      </div>
       <p class="alert alert-info" role="alert">
         Please do work through the Getting Started guide, even if you do know how to build such an application.  The guide covers the basics of working with Heroku, and will familiarize you with all the concepts you need in order to build and deploy your own apps.
       </p>

--- a/views/partials/nav.ejs
+++ b/views/partials/nav.ejs
@@ -36,7 +36,7 @@
           <li><a href="https://devcenter.heroku.com/articles/getting-started-with-clojure-fir">Getting Started on Heroku Fir with Clojure</a></li>
           <li><a href="https://devcenter.heroku.com/articles/getting-started-with-scala-fir">Getting Started on Heroku Fir with Scala</a></li>
           <li><a href="https://devcenter.heroku.com/articles/getting-started-with-go-fir">Getting Started on Heroku Fir with Go</a></li>
-          <li><a href="https://devcenter.heroku.com/articles/getting-started-with-dotnet-fir">Getting Started on Heroku with .Net</a></li>
+          <li><a href="https://devcenter.heroku.com/articles/getting-started-with-dotnet-fir">Getting Started on Heroku Fir with .Net</a></li>
           <li class="divider"></li>
           <li><a href="https://devcenter.heroku.com/articles/getting-started-with-heroku-and-connect-without-local-dev">Getting Started on Heroku with Heroku Connect</a></li>
         </ul>

--- a/views/partials/nav.ejs
+++ b/views/partials/nav.ejs
@@ -8,20 +8,38 @@
         <a href="https://devcenter.heroku.com/articles/how-heroku-works"><span class="glyphicon glyphicon-user"></span> How Heroku Works</a>
       </li>
       <li class="dropdown">
-        <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false"><span class="glyphicon glyphicon-info-sign"></span> Getting Started Guides <span class="caret"></span></a>
+        <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false"><span class="glyphicon glyphicon-info-sign"></span> Getting Started Guides (Cedar) <span class="caret"></span></a>
           <ul class="dropdown-menu" role="menu">
             <li><a href="https://devcenter.heroku.com/articles/getting-started-with-ruby">Getting Started on Heroku with Ruby</a></li>
             <li><a href="https://devcenter.heroku.com/articles/getting-started-with-nodejs">Getting Started on Heroku with Node.js</a></li>
             <li><a href="https://devcenter.heroku.com/articles/getting-started-with-php">Getting Started on Heroku with PHP</a></li>
             <li><a href="https://devcenter.heroku.com/articles/getting-started-with-python">Getting Started on Heroku with Python</a></li>
             <li><a href="https://devcenter.heroku.com/articles/getting-started-with-java">Getting Started on Heroku with Java</a></li>
-            <li><a href="https://devcenter.heroku.com/articles/getting-started-with-go">Getting Started on Heroku with Go</a></li>
             <li><a href="https://devcenter.heroku.com/articles/getting-started-with-clojure">Getting Started on Heroku with Clojure</a></li>
             <li><a href="https://devcenter.heroku.com/articles/getting-started-with-scala">Getting Started on Heroku with Scala</a></li>
+            <li><a href="https://devcenter.heroku.com/articles/getting-started-with-go">Getting Started on Heroku with Go</a></li>
+            <li><a href="https://devcenter.heroku.com/articles/getting-started-with-dotnet">Getting Started on Heroku with .Net</a></li>
             <li class="divider"></li>
             <li><a href="https://devcenter.heroku.com/articles/getting-started-with-heroku-and-connect-without-local-dev">Getting Started on Heroku with Heroku Connect</a></li>
             <li><a href="https://devcenter.heroku.com/articles/getting-started-with-jruby">Getting Started on Heroku with Ruby (Microsoft Windows)</a></li>
           </ul>
+      </li>
+      <li class="dropdown">
+        <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false"><span class="glyphicon glyphicon-info-sign"></span> Getting Started Guides (Fir) <span class="caret"></span></a>
+        <ul class="dropdown-menu" role="menu">
+          <li><a href="https://devcenter.heroku.com/articles/getting-started-with-ruby-fir">Getting Started on Heroku Fir with Ruby</a></li>
+          <li><a href="https://devcenter.heroku.com/articles/getting-started-with-nodejs-fir">Getting Started on Heroku Fir with Node.js</a></li>
+          <li><a href="https://devcenter.heroku.com/articles/getting-started-with-php-fir">Getting Started on Heroku Fir with PHP</a></li>
+          <li><a href="https://devcenter.heroku.com/articles/getting-started-with-python-fir">Getting Started on Heroku Fir with Python</a></li>
+          <li><a href="https://devcenter.heroku.com/articles/getting-started-with-java-maven-fir">Getting Started on Heroku Fir with Java (Maven)</a></li>
+          <li><a href="https://devcenter.heroku.com/articles/getting-started-with-java-gradle-fir">Getting Started on Heroku Fir with Java (Gradle)</a></li>
+          <li><a href="https://devcenter.heroku.com/articles/getting-started-with-clojure-fir">Getting Started on Heroku Fir with Clojure</a></li>
+          <li><a href="https://devcenter.heroku.com/articles/getting-started-with-scala-fir">Getting Started on Heroku Fir with Scala</a></li>
+          <li><a href="https://devcenter.heroku.com/articles/getting-started-with-go-fir">Getting Started on Heroku Fir with Go</a></li>
+          <li><a href="https://devcenter.heroku.com/articles/getting-started-with-dotnet-fir">Getting Started on Heroku with .Net</a></li>
+          <li class="divider"></li>
+          <li><a href="https://devcenter.heroku.com/articles/getting-started-with-heroku-and-connect-without-local-dev">Getting Started on Heroku with Heroku Connect</a></li>
+        </ul>
       </li>
     </ul>
     <ul class="nav navbar-nav navbar-right">


### PR DESCRIPTION
* Updated the README with fir-related links and removed references to the "Deploy to Heroku" button

* Updated the site navigation to include a new section for fir-related links (also added links to .Net guides to both navs)
![Screenshot 2024-12-04 at 2 40 31 PM](https://github.com/user-attachments/assets/3a65d293-6da9-498e-b1a4-e8301da07a46)

* Updated the jumbotron to include a button for the Node.js Fir guide
![Screenshot 2024-12-04 at 2 41 09 PM](https://github.com/user-attachments/assets/c587cef8-c087-429d-b188-3b883b068da5)

* Updated the content to include links to Node.js Fir guide, replaced usage of "slug" with "build artifacts", and removed references to the "Deploy to Heroku" button
![Screenshot 2024-12-04 at 2 55 08 PM](https://github.com/user-attachments/assets/6e4ef924-c35e-41bf-a3ff-81b9a5ff72ac)
