### PR TITLE
Remove `logo` from app.json

### DIFF
--- a/app.json
+++ b/app.json
@@ -2,7 +2,6 @@
   "name": "Start on Heroku: Node.js",
   "description": "A barebones Node.js app using Express 4",
   "repository": "https://github.com/heroku/node-js-getting-started",
-  "logo": "https://cdn.rawgit.com/heroku/node-js-getting-started/main/public/node.svg",
   "keywords": ["node", "express", "heroku"],
   "image": "heroku/nodejs"
 }


### PR DESCRIPTION
Since Dashboard no longer uses it, and none of the other language repos have this field set.

See also:
https://salesforce-internal.slack.com/archives/C07TTSR4SUB/p1743725458507469