### PR TITLE
Add cleanup comment to SIGTERM handler

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,4 +33,5 @@ process.on('SIGTERM', async () => {
       console.log('HTTP server closed')
     })
   }
+  // Cleanup after server close
 })


### PR DESCRIPTION
The [Getting Started with Node.js](https://devcenter.heroku.com/articles/getting-started-with-nodejs) tutorial uses `file.append` with a line-number target to insert `pool.end()` into this SIGTERM handler during the "Provision a Database" step.

Without a clear landmark after the `server.close` block, the line number is easy to get wrong. It's been wrong — `pool.end()` was landing at module scope between `server.keepAliveTimeout` and the handler, closing the database pool on startup instead of on shutdown:

```js
server.keepAliveTimeout = 95 * 1000
  pool.end().then(() => {       // runs immediately — not on SIGTERM
    console.log('PG pool closed')
  })

process.on('SIGTERM', async () => {
  // ...
})
```

This adds a single comment inside the handler that makes the insertion point obvious:

```js
process.on('SIGTERM', async () => {
  console.log('SIGTERM signal received: gracefully shutting down')
  if (server) {
    server.close(() => {
      console.log('HTTP server closed')
    })
  }
  // Cleanup after server close
})
```

The comment reads naturally on its own (it describes the logical section of the handler), and gives the tutorial a stable reference point.

Once this is added, we can add some APIs to rundoc like

```
file.before(match: "// Cleanup after server close")
file.after(match: "// Cleanup after server close")
```