### PR TITLE
Specify npm 12.x in engines to suppress version upgrade notices

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "private": true,
   "description": "A sample Node.js app using Express",
   "engines": {
-    "node": "20.x || 22.x || 24.x",
-    "npm": "11.*"
+    "node": "22.x || 24.x || 26.x",
+    "npm": "11.x"
   },
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A sample Node.js app using Express",
   "engines": {
     "node": "22.x || 24.x || 26.x",
-    "npm": "11.x"
+    "npm": "12.x"
   },
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "private": true,
   "description": "A sample Node.js app using Express",
   "engines": {
-    "node": "20.x || 22.x || 24.x"
+    "node": "20.x || 22.x || 24.x",
+    "npm": "11.*"
   },
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Node 24.16.0 bundles npm 11.13.0 but npm 12.0.0 has since been released. Since the buildpack uses whatever npm ships with the Node binary (there's no buildpack-level default to update), npm prints upgrade notices on every invocation during the build:

```
remote:        npm notice
remote:        npm notice New minor version of npm available! 11.13.0 -> 11.16.0
remote:        npm notice Changelog: https://github.com/npm/cli/releases/tag/v11.16.0
remote:        npm notice To update run: npm install -g npm@11.16.0
remote:        npm notice
```

This block appears 5 times in the generated getting started tutorial (twice per deploy during install + prune, across 2 deploys + the db provision step).

Adding `"npm": "12.x"` to engines tells the buildpack to resolve and install the latest npm release line, which eliminates the notices.